### PR TITLE
酷安名称第一位大小写修正（已失效

### DIFF
--- a/README_en_US.md
+++ b/README_en_US.md
@@ -18,7 +18,7 @@ The list of the above companies, which are basically not affiliated with 996, is
 
 * Autodesk - Beijing/Shanghai
 * Cisco - Beijing/Shanghai/Hangzhou/Suzhou
-* coolapk (酷安) - Beijing/Shenzhen
+* Coolapk (酷安) - Beijing/Shenzhen
 * Douban (豆瓣) - Beijing
 * eBay - Shanghai
 * EMC - Shanghai


### PR DESCRIPTION
如题