### PR TITLE
[fix #58] remove ThoughtWorks from 955 for accuracy

### DIFF
--- a/README_en_US.md
+++ b/README_en_US.md
@@ -71,7 +71,6 @@ The list of companies below, which are basically not affiliated with 996, is rel
 * SmartNews - Beijing/Shanghai
 * State Street - Hangzhou
 * SUSE - Beijing/Shanghai/Shenzhen
-* ThoughtWorks - Xi'an/Beijing/Shenzhen/Chengdu/Wuhan/Shanghai/HongKong
 * Trend Micro - Nanjing
 * Ubisoft - Shanghai
 * Unity - Shanghai


### PR DESCRIPTION
ThoughtWorks is not always following 955 working hours, as client requests it may vary dramatically from 955 to 9105 or even more in some special cases