### PR TITLE
Update README.md to add Canva to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 * Autodesk - 北京/上海
 * Booking - 上海
 * Calix - 南京
+* Canva - 北京/武汉
 * Citrix - 南京
 * Cisco - 北京/上海/杭州/苏州
 * Coolapk (酷安) - 北京/深圳

--- a/README_en_US.md
+++ b/README_en_US.md
@@ -38,6 +38,7 @@ The list of companies below, which are basically not affiliated with 996, is rel
 * Autodesk - Beijing/Shanghai
 * Booking - Shanghai
 * Calix - Nanjing
+* Canva - Beijing/Wuhan
 * Citrix - Nanjing
 * Cisco - Beijing/Shanghai/Hangzhou/Suzhou
 * Coolapk (酷安) - Beijing/Shenzhen


### PR DESCRIPTION
Adding Canva to the list. 

[Canva](https://www.canva.cn/about/) is an Australian graphic design platform, whose headquarter is located in Sydney. Canva opened the Beijing and Wuhan offices in 2018, and is very proud of its rich culture and work-life-balance.